### PR TITLE
ci: release arm64 build for docker-plugin

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,7 @@ builds:
       - linux
       #- darwin
     goarch:
-      #- arm64
+      - arm64
       - amd64
     main: ./cmd/
 archives:


### PR DESCRIPTION


# Summary

Add arm64 build support

---


**Related issue :**

fixes https://github.com/interTwin-eu/interlink-docker-plugin/issues/7
